### PR TITLE
Change import from 'ember-intl-cp-validations' to '@ember-intl/cp-validations'

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To change the errors prefix key from `errors` to any other key, such as `validat
 ```js
 // app/validators/messages.js
 
-import ValidatorsMessages from 'ember-intl-cp-validations/validators/messages';
+import ValidatorsMessages from '@ember-intl/cp-validations/validators/messages';
 
 export default ValidatorsMessages.extend({
   prefix: 'validationErrors'

--- a/addon/validators/messages.js
+++ b/addon/validators/messages.js
@@ -60,7 +60,7 @@ export default ValidatorsMessages.extend({
       return this.formatMessage(intl.t(key, options));
     }
 
-    this._warn(`[ember-intl-cp-validations] Missing translation for validation key: ${key}\nhttp://offirgolan.github.io/ember-cp-validations/docs/messages/index.html`, false, {
+    this._warn(`[@ember-intl/cp-validations] Missing translation for validation key: ${key}\nhttp://offirgolan.github.io/ember-cp-validations/docs/messages/index.html`, false, {
       id: 'ember-intl-cp-validations-missing-translation'
     });
 

--- a/app/validators/messages.js
+++ b/app/validators/messages.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-intl-cp-validations/validators/messages';
+export { default } from '@ember-intl/cp-validations/validators/messages';

--- a/index.js
+++ b/index.js
@@ -2,5 +2,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-intl-cp-validations'
+  name: require('./package').name,
 };

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,4 +1,4 @@
-<h2 id="title">ember-intl-cp-validations</h2>
+<h2 id="title">@ember-intl/cp-validations</h2>
 
 <div class="email-validation">{{model.validations.attrs.email.message}}</div>
 <div class="emailConfirmation-validation">{{model.validations.attrs.emailConfirmation.message}}</div>

--- a/tests/unit/validators/messages-test.js
+++ b/tests/unit/validators/messages-test.js
@@ -1,6 +1,6 @@
 import { moduleFor, test } from 'ember-qunit';
 
-moduleFor('ember-intl-cp-validations@validator:messages', 'Unit | Validators | messages', {
+moduleFor('@ember-intl/cp-validations@validator:messages', 'Unit | Validators | messages', {
   unit: true,
   needs: [
     'service:intl',


### PR DESCRIPTION
The following error fails the tests in #87 

> ember-cli: Your names in package.json and index.js should match. The addon in /home/runner/work/cp-validations/cp-validations currently have '@ember-intl/cp-validations' in package.json and 'ember-intl-cp-validations' in index.js.
> Until ember-cli v3.9, this error can be disabled by setting env variable EMBER_CLI_IGNORE_ADDON_NAME_MISMATCH to "true". For more information about this workaround, see: https://github.com/ember-cli/ember-cli/pull/7950.

Before:
```js
import ValidatorsMessages from 'ember-intl-cp-validations/validators/messages';
```

After:
```js
import ValidatorsMessages from '@ember-intl/cp-validations/validators/messages';
```

Ref https://github.com/ember-intl/cp-validations/issues/85