### PR TITLE
Tested ember-intl compatibility

### DIFF
--- a/.changeset/nasty-fireants-prove.md
+++ b/.changeset/nasty-fireants-prove.md
@@ -1,0 +1,5 @@
+---
+"@ember-intl/cp-validations": patch
+---
+
+Tested compatibilities with ember-intl@v6 and ember-intl@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
+          - 'ember-intl-6'
           - 'ember-lts-3.28'
           - 'ember-lts-4.12'
           - 'ember-lts-5.4'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Adds support for [ember-intl](https://github.com/yahoo/ember-intl) in ember-cp-v
 * Ember.js v3.28 or above
 * Node.js v18 or above
 * `ember-cp-validations` v6
-* `ember-intl` v6
+* `ember-intl` v6 or above
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-cp-validations": "^6.0.1",
-    "ember-intl": "^6.1.0",
+    "ember-intl": "^7.0.4",
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^8.2.3",
     "ember-qunit": "^8.0.2",
@@ -84,7 +84,7 @@
   },
   "peerDependencies": {
     "ember-cp-validations": "^6.0.0",
-    "ember-intl": "^6.1.0"
+    "ember-intl": "^6.1.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "ember-intl": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ devDependencies:
     specifier: ^6.0.1
     version: 6.0.1(ember-source@5.10.0)
   ember-intl:
-    specifier: ^6.1.0
-    version: 6.5.5(webpack@5.92.1)
+    specifier: ^7.0.4
+    version: 7.0.4(webpack@5.92.1)
   ember-load-initializers:
     specifier: ^2.1.2
     version: 2.1.2(@babel/core@7.24.7)
@@ -3885,8 +3885,8 @@ packages:
       static-extend: 0.1.2
     dev: true
 
-  /cldr-core@44.1.0:
-    resolution: {integrity: sha512-ssbJaXu3pCkc4YqNC6xHhgleZG7YqnOFZ9laMlJfHOfnspoA9waI4AH54gKB3Fe/+wI4i3cVxKFdCTVGTRw+UA==}
+  /cldr-core@45.0.0:
+    resolution: {integrity: sha512-gQVxy3gzOQpXiTRGmlKiRQFLYimrr1RgvqGKZCS61JgmdkeNm7+LZGx+Lhw5/AW0t8WMM/uZhf4CMva6LuUobQ==}
     dev: true
 
   /clean-base-url@1.0.0:
@@ -5216,11 +5216,11 @@ packages:
       - eslint
     dev: true
 
-  /ember-intl@6.5.5(webpack@5.92.1):
-    resolution: {integrity: sha512-ce+SyhrnzHMgxuX7eIv1PSs5GY0uJpG/33QxGMvrRqavDEzvhhAq9G56dedoMygFT6bKPr/dZuLpDmz7hhk8Kg==}
-    engines: {node: 16.* || >= 18}
+  /ember-intl@7.0.4(webpack@5.92.1):
+    resolution: {integrity: sha512-EKIEV24BiUTx05+zi1Y37+qaOwVO/bFMZtsHPzndMDJcj6wjC1e3aMm5nvs4+jldh1TVwnIMVs9ivEoUNeijHQ==}
+    engines: {node: 18.* || >= 20}
     peerDependencies:
-      typescript: ^4.8.0 || ^5.0.0
+      typescript: ^5.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5232,19 +5232,16 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       broccoli-source: 3.0.1
-      broccoli-stew: 3.0.0
       calculate-cache-key-for-tree: 2.0.0
-      cldr-core: 44.1.0
+      cldr-core: 45.0.0
       ember-auto-import: 2.7.4(webpack@5.92.1)
       ember-cli-babel: 8.2.0(@babel/core@7.24.7)
       ember-cli-typescript: 5.3.0
       eventemitter3: 5.0.1
       extend: 3.0.2
-      fast-memoize: 2.5.2
       intl-messageformat: 10.5.14
       js-yaml: 4.1.0
       json-stable-stringify: 1.1.1
-      silent-error: 1.1.1
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -6232,10 +6229,6 @@ packages:
 
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-    dev: true
-
-  /fast-memoize@2.5.2:
-    resolution: {integrity: sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==}
     dev: true
 
   /fast-ordered-set@1.0.3:

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -9,6 +9,16 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
+        name: 'ember-intl-6',
+        npm: {
+          devDependencies: {
+            'ember-intl': await latestVersion('ember-intl', {
+              version: '6',
+            }),
+          },
+        },
+      },
+      {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {


### PR DESCRIPTION
## Description

CI now shows that `@ember-intl/cp-validations` _may_ be compatible with `ember-intl@v6` and `ember-intl@v7`. (Hard to know with certainty due to lack of tests.)
